### PR TITLE
Fix build on newer .NET SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Quasar Changelog
 
+## Quasar v1.4.2 [27.07.2025]
+* **Changed target framework to .NET Framework 4.6.2**
+
 ## Quasar v1.4.1 [12.03.2023]
 * Added missing WOW64 subsystem autostart locations
 * Fixed file transfers of files larger than 2 GB

--- a/Quasar.Client/ILRepack.targets
+++ b/Quasar.Client/ILRepack.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ILRepacker" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release'">
+  <Target Name="ILRepacker" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release' And '$(OS)' == 'Windows_NT'">
 
   <ItemGroup>
     <InputAssemblies Include="$(TargetPath)"/>

--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Client</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>
@@ -25,6 +25,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Management" />
@@ -67,5 +70,6 @@
     <PackageReference Include="protobuf-net">
       <Version>2.4.8</Version>
     </PackageReference>
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Quasar.Common.Tests/Quasar.Common.Tests.csproj
+++ b/Quasar.Common.Tests/Quasar.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Quasar.Common/Quasar.Common.csproj
+++ b/Quasar.Common/Quasar.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Quasar</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>
@@ -314,6 +314,9 @@
     <PackageReference Include="Vestris.ResourceLib">
       <Version>2.1.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.0" />
   </ItemGroup>
-  <PropertyGroup />
+  <PropertyGroup>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add `System.Resources.Extensions` to client and server projects
- enable `GenerateResourceUsePreserializedResources` for desktop apps
- only run ILRepack on Windows

## Testing
- `dotnet build Quasar.sln -c Release`
- `dotnet test Quasar.sln`


------
https://chatgpt.com/codex/tasks/task_e_6885f0cdbda0833396d22e5d548ce27b